### PR TITLE
Allow empty .header-nav; maintain Login position

### DIFF
--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -15,11 +15,11 @@
             </div>
         </div>
 
-        {{#if @site.navigation}}
-            <nav class="header-nav">
+        <nav class="header-nav">
+            {{#if @site.navigation}}
                 {{navigation}}
-            </nav>
-        {{/if}}
+            {{/if}}
+        </nav>
 
         <div class="header-actions">
             <div class="social">


### PR DESCRIPTION
Before the change: If there are no menu items in Settings > Navigation > Primary, then the Login/Account link will move to the center (which looks unbalanced with the logo being left-aligned.)

After the change: The Login/Account links will remain right-justified regardless of the .header-nav content.