### PR TITLE
Change feature image conditional location

### DIFF
--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -7,8 +7,8 @@
             {{date published_at format="DD"}}
         </div>
     </div>
-    <div class="feed-image u-placeholder rectangle">
-        {{#if feature_image}}
+    {{#if feature_image}}
+        <div class="feed-image u-placeholder rectangle">
             <img class="u-object-fit"
                 srcset="{{> srcset}}"
                 sizes="(min-width: 576px) 160px, 90vw"
@@ -16,8 +16,8 @@
                 alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
                 loading="lazy"
             >
-        {{/if}}
-    </div>
+        </div>
+    {{/if}}
     <div class="feed-wrapper">
         <h2 class="feed-title">{{title}}</h2>
         {{#if excerpt}}


### PR DESCRIPTION
Right now, if no feature image is set, an empty grey box is displayed, which gives the impression an image hasn't loaded correctly.

Moving the conditional one level up in the hierarchy fixes this by only including the image box markup when it's needed.